### PR TITLE
Fix NPE for allowedSnapshotDependencies

### DIFF
--- a/src/main/java/com/github/danielflower/mavenplugins/release/PomUpdater.java
+++ b/src/main/java/com/github/danielflower/mavenplugins/release/PomUpdater.java
@@ -117,6 +117,9 @@ public class PomUpdater {
     }
 
     private boolean isAllowedSnapshotDependency(Dependency dependency) {
+        if (allowedSnapshotDependencies == null) {
+            return false;
+        }
         for (Artifact artifact : allowedSnapshotDependencies) {
             if (dependency.getGroupId().equals(artifact.getGroupId()) && dependency.getArtifactId().equals(artifact.getArtifactId())) {
                 return true;


### PR DESCRIPTION
If allowedSnapshotDependencies isn't configured
on this release plugin, currently an NPE will be
thrown.  This patch corrects that.
